### PR TITLE
📦 [Feat, Test] Add support for retrieving single flavour details

### DIFF
--- a/app/flavour/serializers.py
+++ b/app/flavour/serializers.py
@@ -13,5 +13,14 @@ class FlavourSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Flavour
-        fields = ["id", "title", "description", "price", "time_minutes", "link"]
-        ready_only_fields = ["id"]
+        fields = ["id", "title", "price", "time_minutes", "link"]
+        read_only_fields = ["id"]
+
+
+class FlavourDetailSerializer(FlavourSerializer):
+    """Serializes single flavour details."""
+
+    class Meta(FlavourSerializer.Meta):
+        """Inherite attributes from 'cls: FlavourSerializer' to build this class."""
+
+        fields = FlavourSerializer.Meta.fields + ["description"]

--- a/app/flavour/tests/test_flavour_api.py
+++ b/app/flavour/tests/test_flavour_api.py
@@ -12,9 +12,14 @@ from rest_framework.test import APIClient
 
 from core.models import Flavour
 
-from ..serializers import FlavourSerializer
+from ..serializers import FlavourDetailSerializer, FlavourSerializer
 
 FLAVOUR_URL = reverse("flavour:flavour-list")
+
+
+def flavour_detail_url(flavour_id):
+    """Returns custom flavour URL."""
+    return reverse("flavour:flavour-detail", args=[flavour_id])
 
 
 def create_user(**params):
@@ -97,3 +102,15 @@ class PrivateFlavourAPITests(TestCase):
         self.assertEqual(response.data, serializer.data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_retrieve_flavour_details(self):
+        """Test retriving single flavour detail."""
+        flavour = create_flavour(user=self.user)
+
+        url = flavour_detail_url(flavour.id)
+        response = self.client.get(url)
+
+        serializer = FlavourDetailSerializer(flavour)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)

--- a/app/flavour/views.py
+++ b/app/flavour/views.py
@@ -7,7 +7,7 @@ from rest_framework.permissions import IsAuthenticated
 
 from core.models import Flavour
 
-from .serializers import FlavourSerializer
+from .serializers import FlavourDetailSerializer, FlavourSerializer
 
 
 class FlavourViewSet(viewsets.ModelViewSet):
@@ -22,3 +22,9 @@ class FlavourViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         """Return flavour query only for authenticated user."""
         return self.queryset.filter(user=self.request.user).order_by("-id")
+
+    def get_serializer_class(self):
+        """Overrides the above 'serializer_class' and returns serializer class depending on list or detail request."""
+        if self.action == "list":
+            return FlavourSerializer
+        return FlavourDetailSerializer


### PR DESCRIPTION
This PR enhances the Flavour API by enabling detailed retrieval of a single flavour record.

**What’s Included:**

- ✅ **New Test Case**
  - Added `test_retrieve_flavour_details()` to validate single flavour retrieval.
  - Defined `flavour_detail_url()` helper for generating detail view endpoint URLs.
  - Ensured response matches serialized output using `FlavourDetailSerializer`.

- 🧱 **Serializer Enhancement**
  - Created `FlavourDetailSerializer` by extending `FlavourSerializer`.
  - Included the `description` field to enrich detailed responses.

- ⚙️ **Dynamic Serializer Handling**
  - Overrode `get_serializer_class()` in `FlavourViewSet`.
  - Automatically selects `FlavourDetailSerializer` for `retrieve` actions and `FlavourSerializer` for `list` actions.

All tests and linters are passing ✅